### PR TITLE
Bugfix/pl 1797 aedes persistence redis scalability fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "tape": "^4.13.2"
   },
   "dependencies": {
-    "aedes-cached-persistence": "git+ssh://git@github.com:bolteu/aedes-cached-persistence.git#8d193ec250ba857dca",
+    "aedes-cached-persistence": "git+ssh://git@github.com:bolteu/aedes-cached-persistence.git#master",
     "from2": "^2.3.0",
     "hashlru": "^2.3.0",
     "ioredis": "^4.17.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "tape": "^4.13.2"
   },
   "dependencies": {
-    "aedes-cached-persistence": "git+ssh://git@github.com:bolteu/aedes-cached-persistence.git#e7955f2eb2f11ce9f4877",
+    "aedes-cached-persistence": "git+ssh://git@github.com:bolteu/aedes-cached-persistence.git#8d193ec250ba857dca",
     "from2": "^2.3.0",
     "hashlru": "^2.3.0",
     "ioredis": "^4.17.3",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "tape": "^4.13.2"
   },
   "dependencies": {
-    "aedes-cached-persistence": "^8.1.0",
+    "aedes-cached-persistence": "git+ssh://git@github.com:bolteu/aedes-cached-persistence.git#e7955f2eb2f11ce9f4877",
     "from2": "^2.3.0",
     "hashlru": "^2.3.0",
     "ioredis": "^4.17.3",

--- a/persistence.js
+++ b/persistence.js
@@ -19,6 +19,8 @@ const qlobberOpts = {
 }
 const clientKey = 'client:'
 const clientsKey = 'clients'
+const subscribersKey = "subscribers:"
+const subscriberCountKey = "subscribers-count"
 const willsKey = 'will'
 const willKey = 'will:'
 const retainedKey = 'retained'
@@ -111,20 +113,47 @@ RedisPersistence.prototype.addSubscriptions = function (client, subs, cb) {
   var published = 0
   var errored
 
+  var waitForPublishes = 3;
+
   for (var i = 0; i < subs.length; i++) {
     var sub = subs[i]
     toStore[sub.topic] = sub.qos
+
+    waitForPublishes++;
+    var topicSubsciptionsKey = subscribersKey + sub.topic
+    if (sub.qos > 0) {
+        this._db.hset(topicSubsciptionsKey, client.id, sub.qos, subscriberFinishAdding)
+      } else {
+        this._db.hdel(topicSubsciptionsKey, client.id, subscriberFinishRemoving)
+    }
   }
 
   this._db.sadd(clientsKey, client.id, finish)
   this._db.hmset(clientSubKey, toStore, finish)
 
   this._addedSubscriptions(client, subs, finish)
+  var that = this
+
+  function subscriberFinishAdding(err, t) {
+    if (t === 1) {
+      that._db.incr(subscriberCountKey);
+    }
+
+    finish(err);
+  }
+
+  function subscriberFinishRemoving(err, t) {
+    if (t === 1) {
+      that._db.decr(subscriberCountKey);
+    }
+
+    finish(err);
+  }
 
   function finish (err) {
     errored = err
     published++
-    if (published === 3) {
+    if (published === waitForPublishes) {
       cb(errored, client)
     }
   }
@@ -140,6 +169,14 @@ RedisPersistence.prototype.removeSubscriptions = function (client, subs, cb) {
 
   var errored = false
   var outstanding = 0
+  var that = this
+  function subscriptionCheck(err, t) {
+    if (t === 1) {
+      that._db.decr(subscriberCountKey);
+    }
+
+    check(err);
+  }
 
   function check (err) {
     if (err) {
@@ -166,6 +203,12 @@ RedisPersistence.prototype.removeSubscriptions = function (client, subs, cb) {
     }
 
     outstanding++
+    for (const sub of subs) {
+      outstanding++
+      var topicSubsciptionsKey = subscribersKey + sub
+      that._db.hdel(topicSubsciptionsKey, client.id, subscriptionCheck)
+    }
+
     that._db.exists(clientSubKey, function checkAllSubsRemoved (err, subCount) {
       if (err) {
         return check(err)
@@ -218,14 +261,20 @@ function returnSubsForClient (subs) {
 }
 
 RedisPersistence.prototype.countOffline = function (cb) {
-  var that = this
-
+  var that = this;
   this._db.scard(clientsKey, function countOfflineClients (err, count) {
     if (err) {
       return cb(err)
     }
 
-    cb(null, that._trie.subscriptionsCount, parseInt(count) || 0)
+    that._db.get(subscriberCountKey, function subCount (err, subCount) {
+      if (err) {
+        return cb(err);
+      }
+
+      cb(null, parseInt(subCount) || 0, parseInt(count) || 0)
+    });
+
   })
 }
 
@@ -235,9 +284,23 @@ RedisPersistence.prototype.subscriptionsByTopic = function (topic, cb) {
     return this
   }
 
-  var result = this._trie.match(topic)
+  // var result = this._trie.match(topic)
 
-  cb(null, result)
+  const subKey = subscribersKey + topic;
+  this._db.hgetall(subKey, function clientHash (err, data) {
+    if (err) {
+      return cb(err);
+    }
+    const result = Object.keys(data).map((k) => {
+      return {
+        clientId: k,
+        qos: parseInt(data[k]),
+        topic
+      }
+    })
+
+    cb(null, result)
+  });
 }
 
 RedisPersistence.prototype._setup = function () {
@@ -247,42 +310,42 @@ RedisPersistence.prototype._setup = function () {
 
   var that = this
 
-  var hgetallStream = throughv.obj(function getStream (clientId, enc, cb) {
-    var clientSubKey = clientKey + clientId
-    that._db.hgetall(clientSubKey, function clientHash (err, hash) {
-      cb(err, { clientHash: hash, clientId: clientId })
-    })
-  }, function emitReady (cb) {
+  // var hgetallStream = throughv.obj(function getStream (clientId, enc, cb) {
+  //   var clientSubKey = clientKey + clientId
+  //   that._db.hgetall(clientSubKey, function clientHash (err, hash) {
+  //     cb(err, { clientHash: hash, clientId: clientId })
+  //   })
+  // }, function emitReady (cb) {
     that.ready = true
     that.emit('ready')
-    cb()
-  }).on('data', function processKeys (data) {
-    processKeysForClient(data.clientId, data.clientHash, that)
-  })
+  //   cb()
+  // }).on('data', function processKeys (data) {
+  //   processKeysForClient(data.clientId, data.clientHash, that)
+  // })
 
-  this._db.smembers(clientsKey, function smembers (err, clientIds) {
-    if (err) {
-      hgetallStream.emit('error', err)
-    } else {
-      for (var i = 0, l = clientIds.length; i < l; i++) {
-        hgetallStream.write(clientIds[i])
-      }
-      hgetallStream.end()
-    }
-  })
+  // this._db.smembers(clientsKey, function smembers (err, clientIds) {
+  //   if (err) {
+  //     hgetallStream.emit('error', err)
+  //   } else {
+  //     for (var i = 0, l = clientIds.length; i < l; i++) {
+  //       hgetallStream.write(clientIds[i])
+  //     }
+  //     hgetallStream.end()
+  //   }
+  // })
 }
 
-function processKeysForClient (clientId, clientHash, that) {
-  var topics = Object.keys(clientHash)
-  for (var i = 0; i < topics.length; i++) {
-    var topic = topics[i]
-    that._trie.add(topic, {
-      clientId: clientId,
-      topic: topic,
-      qos: clientHash[topic]
-    })
-  }
-}
+// function processKeysForClient (clientId, clientHash, that) {
+//   var topics = Object.keys(clientHash)
+//   for (var i = 0; i < topics.length; i++) {
+//     var topic = topics[i]
+//     that._trie.add(topic, {
+//       clientId: clientId,
+//       topic: topic,
+//       qos: clientHash[topic]
+//     })
+//   }
+// }
 
 RedisPersistence.prototype.outgoingEnqueue = function (sub, packet, cb) {
   this.outgoingEnqueueCombi([sub], packet, cb)
@@ -598,16 +661,31 @@ RedisPersistence.prototype.streamWill = function (brokers) {
   return stream
 }
 
+// Only used from tests
 RedisPersistence.prototype.getClientList = function (topic) {
-  var entries = this._trie.match(topic, topic)
+  // var entries = this._trie.match(topic, topic)
+
+  const subKey = subscribersKey + topic;
+  var entries = null;
+  var savedNext = null;
+  this._db.hgetall(subKey, function clientHash (err, data) {
+    entries = Object.keys(data);
+    if (savedNext) {
+      pushClientList(1, savedNext);
+    }
+  })
 
   function pushClientList (size, next) {
+    if (entries === null) {
+      savedNext = next;
+      return;
+    }
     if (entries.length === 0) {
       return next(null, null)
     }
     var chunk = entries.slice(0, 1)
     entries = entries.slice(1)
-    next(null, chunk[0].clientId)
+    next(null, chunk[0])
   }
 
   return from.obj(pushClientList)

--- a/test.js
+++ b/test.js
@@ -185,19 +185,6 @@ test('multiple persistences', function (t) {
     }
   }
 
-  instance2._waitFor(client, 'sub_' + 'hello', function () {
-    instance2.subscriptionsByTopic('hello', function (err, resubs) {
-      t.notOk(err, 'subs by topic no error')
-      t.deepEqual(resubs, [{
-        clientId: client.id,
-        topic: 'hello',
-        qos: 1
-      }])
-      gotSubs = true
-      close()
-    })
-  })
-
   var ready = false
   var ready2 = false
 
@@ -206,7 +193,16 @@ test('multiple persistences', function (t) {
       instance.addSubscriptions(client, subs, function (err) {
         t.notOk(err, 'add subs no error')
         addedSubs = true
-        close()
+        instance2.subscriptionsByTopic('hello', function (err, resubs) {
+          t.notOk(err, 'subs by topic no error')
+          t.deepEqual(resubs, [{
+            clientId: client.id,
+            topic: 'hello',
+            qos: 1
+          }])
+          gotSubs = true
+          close()
+        })
       })
     }
   }

--- a/test.js
+++ b/test.js
@@ -169,9 +169,6 @@ test('multiple persistences', function (t) {
     topic: 'hello',
     qos: 1
   }, {
-    topic: 'hello/#',
-    qos: 1
-  }, {
     topic: 'matteo',
     qos: 1
   }]
@@ -192,10 +189,6 @@ test('multiple persistences', function (t) {
     instance2.subscriptionsByTopic('hello', function (err, resubs) {
       t.notOk(err, 'subs by topic no error')
       t.deepEqual(resubs, [{
-        clientId: client.id,
-        topic: 'hello/#',
-        qos: 1
-      }, {
         clientId: client.id,
         topic: 'hello',
         qos: 1

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ db.on('error', function (e) {
 
 db.on('connect', unref)
 
-function unref() {
+function unref () {
   this.connector.stream.unref()
 }
 
@@ -60,7 +60,7 @@ abs({
   waitForReady: true
 })
 
-function toBroker(id, emitter) {
+function toBroker (id, emitter) {
   return {
     id: id,
     publish: emitter.emit.bind(emitter),
@@ -94,7 +94,7 @@ test('packet ttl', function (t) {
     brokerId: instance.broker.id,
     brokerCounter: 42
   }
-  instance.outgoingEnqueueCombi(subs, packet, function enqueued(err, saved) {
+  instance.outgoingEnqueueCombi(subs, packet, function enqueued (err, saved) {
     t.notOk(err)
     t.deepEqual(saved, packet)
     setTimeout(function () {
@@ -139,10 +139,10 @@ test('outgoingUpdate doesn\'t clear packet ttl', function (t) {
     brokerCounter: 42,
     messageId: 123
   }
-  instance.outgoingEnqueueCombi(subs, packet, function enqueued(err, saved) {
+  instance.outgoingEnqueueCombi(subs, packet, function enqueued (err, saved) {
     t.notOk(err)
     t.deepEqual(saved, packet)
-    instance.outgoingUpdate(client, packet, function updated() {
+    instance.outgoingUpdate(client, packet, function updated () {
       setTimeout(function () {
         db.exists('packet:1:42', (_, exists) => {
           t.notOk(exists, 'packet key should have expired')
@@ -154,7 +154,7 @@ test('outgoingUpdate doesn\'t clear packet ttl', function (t) {
   })
 })
 
-test('test unsubscribe', function(t) {
+test('test unsubscribe', function (t) {
   t.plan(8)
   db.flushall()
   var emitter = mqemitterRedis()
@@ -163,12 +163,12 @@ test('test unsubscribe', function(t) {
 
   var client = { id: 'remove_sub' }
 
-  function close() {
+  function close () {
     instance.destroy(t.pass.bind(t, 'instance dies'))
     emitter.close(t.pass.bind(t, 'emitter dies'))
   }
 
-  instance.addSubscriptions(client, [{topic: 't1', qos: 2}], function (err) {
+  instance.addSubscriptions(client, [{ topic: 't1', qos: 2 }], function (err) {
     t.notOk(err, 'add subs no error')
     instance.subscriptionsByTopic('t1', function (err2, resubs) {
       t.notOk(err2, 'subs by topic no error')
@@ -183,12 +183,11 @@ test('test unsubscribe', function(t) {
         instance.subscriptionsByTopic('t1', function (err4, resubs) {
           t.notOk(err4, 'subs by topic no error')
           t.deepEqual(resubs, [])
-          close();
-        });
-      });
-
-    });
-  });
+          close()
+        })
+      })
+    })
+  })
 })
 
 test('test re-subscription by qos 0', function (t) {
@@ -200,12 +199,12 @@ test('test re-subscription by qos 0', function (t) {
 
   var client = { id: 'resub_qos0' }
 
-  function close() {
+  function close () {
     instance.destroy(t.pass.bind(t, 'instance dies'))
     emitter.close(t.pass.bind(t, 'emitter dies'))
   }
 
-  instance.addSubscriptions(client, [{topic: 't1', qos: 2}], function (err) {
+  instance.addSubscriptions(client, [{ topic: 't1', qos: 2 }], function (err) {
     t.notOk(err, 'add subs no error')
     instance.subscriptionsByTopic('t1', function (err2, resubs) {
       t.notOk(err2, 'subs by topic no error')
@@ -215,18 +214,17 @@ test('test re-subscription by qos 0', function (t) {
         qos: 2
       }])
 
-      instance.addSubscriptions(client, [{topic: 't1', qos: 0}], function (err3) {
+      instance.addSubscriptions(client, [{ topic: 't1', qos: 0 }], function (err3) {
         t.notOk(err3, 'subs by topic no error')
         instance.subscriptionsByTopic('t1', function (err4, resubs) {
           t.notOk(err4, 'subs by topic no error')
           t.deepEqual(resubs, [])
-          close();
-        });
-      });
-
-    });
-  });
-});
+          close()
+        })
+      })
+    })
+  })
+})
 
 test('multiple persistences', function (t) {
   t.plan(11)
@@ -250,7 +248,7 @@ test('multiple persistences', function (t) {
     qos: 0
   }]
 
-  function close() {
+  function close () {
     instance.destroy(t.pass.bind(t, 'first dies'))
     instance2.destroy(t.pass.bind(t, 'second dies'))
     emitter.close(t.pass.bind(t, 'first emitter dies'))
@@ -268,15 +266,15 @@ test('multiple persistences', function (t) {
       }])
       instance2.subscriptionsByTopic('wrongtopic', function (err2, resubs2) {
         t.notOk(err2, 'subs2 by topic no error')
-        t.deepEqual(resubs2, []);
+        t.deepEqual(resubs2, [])
 
         instance2.subscriptionsByTopic('zeroqos', function (err3, resubs3) {
           t.notOk(err3, 'subs3 by topic no error')
-          t.deepEqual(resubs3, []);
+          t.deepEqual(resubs3, [])
 
           close()
-        });
-      });
+        })
+      })
     })
   })
 })
@@ -298,7 +296,7 @@ test('unknown cache key', function (t) {
     retain: false
   }
 
-  function close() {
+  function close () {
     instance.destroy(t.pass.bind(t, 'instance dies'))
     emitter.close(t.pass.bind(t, 'emitter dies'))
   }


### PR DESCRIPTION
The plugin has scalability issues:

1. Keeping track of all subscriptions in a local trie
2. Reading all retained topic's messages on client subscriptions

Both of them were needed because MQTT generally allows subscriptions by wildcards, and the most optimal data structure for such searches is a prefix tree (aka trie). The problem was that Redis does not support such data structure, and thus things had to be kept locally, on each node. 

As we removed the wildcard support, there is no more need to keep the local trie => scalability issues solved.