### PR TITLE
RNTL-19559 add cache for shared subscriptions

### DIFF
--- a/test.js
+++ b/test.js
@@ -53,7 +53,7 @@ abs({
   },
   persistence () {
     db.flushall()
-    return persistence()
+    return persistence({ shared_cache_refresh_interval_sec: 10 })
   },
   waitForReady: true
 })
@@ -304,7 +304,7 @@ test('wills table de-duplicate', t => {
   }
 })
 
-test('check storeShared been deleted after time', t => {
+test('check storeShared was deleted after time', t => {
   t.plan(10)
   db.flushall()
   const instance = persistence()
@@ -319,7 +319,7 @@ test('check storeShared been deleted after time', t => {
         t.equal(result[1], 'someGroup_some/+/topic@$share/someGroup/$client_clientId2/')
         instance.getSharedTopics(inputTopic, (err2, topicResult1) => {
           t.notOk(err2, 'getSharedTopics #1 no error')
-          db.zadd('sharedtowipe', (new Date() / 1000), 'someGroup_some/+/topic@$share/someGroup/$client_clientId/', () => {
+          db.zadd('sharedtowipe', (Date.now() / 1000), 'someGroup_some/+/topic@$share/someGroup/$client_clientId/', () => {
             setTimeout(() => {
               db.zrange('sharedtowipe', 0, -1, (err3, result) => {
                 t.notOk(err3, 'zrange #2 no error')

--- a/tester.js
+++ b/tester.js
@@ -10,7 +10,7 @@ const st = Date.now()
 console.log('Started connecting clients', st)
 
 setInterval(() => {
-  console.log(`${new Date()}-${count} - ${subscriptions}`)
+  console.log(`${Date.now()}-${count} - ${subscriptions}`)
 }, 1000)
 
 function worker (arg, cb) {


### PR DESCRIPTION
Adding option to use cache for shared subscriptions getting. Store results from Redis to local service cahce, and periodically update it from redis. This will significantly reduce load on Redis, and will increase possible vertical Mqtt with shared subscriptions scalability.