### PR TITLE
Task/rntl 25108 - sync fork with upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: ['20', '22']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Start Redis
         working-directory: ./docker
-        run:  docker-compose up -d
+        run:  docker compose up -d
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install
@@ -32,4 +32,4 @@ jobs:
           npm run test
       - name: Run tests - clusters
         run: |
-          node test-clusters.js
+          npm run test:clusters

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,16 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    services:
-            redis:
-                image: redis
-                ports:
-                  - 6379:6379
-                options: --entrypoint redis-server
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Start Redis
+        working-directory: ./docker
+        run:  docker-compose up -d
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -32,3 +30,6 @@ jobs:
       - name: Run tests
         run: |
           npm run test
+      - name: Run tests - clusters
+        run: |
+          node test-clusters.js

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ node_modules
 dump.rdb
 
 package-lock.json
+
+.vscode

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # aedes-persistence-redis
 
 ![.github/workflows/ci.yml](https://github.com/moscajs/aedes-persistence-redis/workflows/.github/workflows/ci.yml/badge.svg)
-[![Dependencies Status](https://david-dm.org/moscajs/aedes-persistence-redis/status.svg)](https://david-dm.org/moscajs/aedes-persistence-redis)
-[![devDependencies Status](https://david-dm.org/moscajs/aedes-persistence-redis/dev-status.svg)](https://david-dm.org/moscajs/aedes-persistence-redis?type=dev)
 \
 [![Known Vulnerabilities](https://snyk.io/test/github/moscajs/aedes-persistence-redis/badge.svg)](https://snyk.io/test/github/moscajs/aedes-persistence-redis)
 [![Coverage Status](https://coveralls.io/repos/moscajs/aedes-persistence-redis/badge.svg?branch=master&service=github)](https://coveralls.io/github/moscajs/aedes-persistence-redis?branch=master)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ aedesPersistenceRedis({
   }, {
     port: 6380,
     host: '127.0.0.1'
-  }])
+  }]),
+  cluster: true
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # aedes-persistence-redis
 
-![.github/workflows/ci.yml](https://github.com/moscajs/aedes-persistence-redis/workflows/.github/workflows/ci.yml/badge.svg)
+![.github/workflows/ci.yml](https://github.com/moscajs/aedes-persistence-redis/actions/workflows/.github/workflows/ci.yml/badge.svg)
 \
 [![Known Vulnerabilities](https://snyk.io/test/github/moscajs/aedes-persistence-redis/badge.svg)](https://snyk.io/test/github/moscajs/aedes-persistence-redis)
 [![Coverage Status](https://coveralls.io/repos/moscajs/aedes-persistence-redis/badge.svg?branch=master&service=github)](https://coveralls.io/github/moscajs/aedes-persistence-redis?branch=master)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,13 @@
 # Upgrade
 
 ## x.x.x to 9.x.x
+
 The database schema has changed between 8.x.x to 9.x.x. 
 
 Start with a clean database if you migrate from x.x.x to 9.x.x
+
+# x.x.x to 10.x.x
+
+The database schema has changed between 9.x.x to 10.x.x **IF YOU ARE USING CLUSTERS**.
+
+Start with a clean database **IF YOU ARE USING CLUSTERS** migrate from x.x.x to 10.x.x or use `migrations.js` `from9to10` function.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+
+services:
+  redis-default:
+    image: redis:6.2.5-alpine
+    command: redis-server --port 6379 --appendonly yes
+    network_mode: "host"
+
+  redis-cluster:
+    image: gsccheng/redis-cluster
+    ports:
+      - '6378:7000'
+      - '6380:7001'
+      - '6381:7002'
+      - '6382:7003'
+      - '6383:7004'
+      - '6384:7005'
+    environment:
+      SENTINEL: 'true'
+      INITIAL_PORT: 7000,
+      MASTERS: 3,
+      SLAVES_PER_MASTER: 1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   redis-default:
     image: redis:6.2.5-alpine

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,1 @@
+module.exports = require('neostandard')({})

--- a/example.js
+++ b/example.js
@@ -4,6 +4,6 @@ const aedes = require('aedes')({
   mq,
   persistence
 })
-const server = require('net').createServer(aedes.handle)
+const server = require('node:net').createServer(aedes.handle)
 
 server.listen(1883)

--- a/migrations.js
+++ b/migrations.js
@@ -1,0 +1,46 @@
+async function from9to10 (db, cb) {
+  // move retained messages from hash to keys
+  const RETAINEDKEY = 'retained'
+  function retainedKey (topic) {
+    return `${RETAINEDKEY}:${encodeURIComponent(topic)}`
+  }
+
+  // get all topics
+  db.hkeys(RETAINEDKEY, function (err, topics) {
+    if (err) {
+      return cb(err)
+    }
+
+    Promise.all(topics.map(t => {
+      return new Promise((resolve, reject) => {
+        // get packet payload
+        db.hgetBuffer(RETAINEDKEY, t, function (err, payload) {
+          if (err) {
+            return reject(err)
+          }
+          // set packet with new format
+          db.set(retainedKey(t), payload, function (err) {
+            if (err) {
+              return reject(err)
+            }
+            // remove old packet
+            db.hdel(RETAINEDKEY, t, function (err) {
+              if (err) {
+                return reject(err)
+              }
+              resolve()
+            })
+          })
+        })
+      })
+    })).then(() => {
+      cb(null)
+    }).catch(err => {
+      cb(err)
+    })
+  })
+}
+
+module.exports = {
+  from9to10
+}

--- a/migrations.js
+++ b/migrations.js
@@ -6,7 +6,7 @@ async function from9to10 (db, cb) {
   }
 
   // get all topics
-  db.hkeys(RETAINEDKEY, function (err, topics) {
+  db.hkeys(RETAINEDKEY, (err, topics) => {
     if (err) {
       return cb(err)
     }
@@ -14,17 +14,17 @@ async function from9to10 (db, cb) {
     Promise.all(topics.map(t => {
       return new Promise((resolve, reject) => {
         // get packet payload
-        db.hgetBuffer(RETAINEDKEY, t, function (err, payload) {
+        db.hgetBuffer(RETAINEDKEY, t, (err, payload) => {
           if (err) {
             return reject(err)
           }
           // set packet with new format
-          db.set(retainedKey(t), payload, function (err) {
+          db.set(retainedKey(t), payload, (err) => {
             if (err) {
               return reject(err)
             }
             // remove old packet
-            db.hdel(RETAINEDKEY, t, function (err) {
+            db.hdel(RETAINEDKEY, t, (err) => {
               if (err) {
                 return reject(err)
               }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aedes-persistence-redis",
-  "version": "11.0.0",
+  "version": "11.0.1",
   "description": "Aedes persistence, backed by redis",
   "main": "persistence.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aedes-persistence-redis",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "description": "Aedes persistence, backed by redis",
   "main": "persistence.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,19 @@
   "version": "10.0.0",
   "description": "Aedes persistence, backed by redis",
   "main": "persistence.js",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
-    "lint": "standard --verbose | snazzy",
-    "test": "tape test.js | faucet",
-    "coverage": "nyc --reporter=lcov tape test.js",
+    "lint": "eslint",
+    "lint:fix": "eslint --fix",
+    "unit": "node --test test.js",
+    "test": "npm run lint && npm run unit",
+    "test:clusters": "node --test test-clusters.js",
+    "coverage": "nyc --reporter=lcov node --test test.js",
     "license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause;Apache-2.0;Apache*'",
-    "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
+    "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics",
+    "redis": "cd docker;docker compose up"
   },
   "release-it": {
     "github": {
@@ -27,7 +34,6 @@
     }
   },
   "pre-commit": [
-    "lint",
     "test"
   ],
   "repository": {
@@ -47,27 +53,21 @@
   },
   "homepage": "https://github.com/moscajs/aedes-persistence-redis#readme",
   "devDependencies": {
-    "fastq": "^1.13.0",
-    "faucet": "0.0.1",
+    "@fastify/pre-commit": "^2.2.0",
+    "eslint": "^9.21.0",
+    "fastq": "^1.19.1",
     "license-checker": "^25.0.1",
-    "mqemitter": "^4.5.0",
-    "mqemitter-redis": "^5.0.0",
-    "mqtt": "^4.3.7",
-    "nyc": "^15.1.0",
-    "pre-commit": "^1.2.2",
-    "release-it": "^15.0.0",
-    "snazzy": "^9.0.0",
-    "standard": "^17.0.0",
-    "tape": "^5.5.3"
+    "mqemitter-redis": "^6.1.0",
+    "mqtt": "^5.10.4",
+    "neostandard": "^0.12.1",
+    "nyc": "^17.1.0",
+    "release-it": "^18.1.2"
   },
   "dependencies": {
-    "aedes-cached-persistence": "^9.0.0",
+    "aedes-cached-persistence": "^10.0.0",
     "hashlru": "^2.3.0",
-    "ioredis": "^5.0.5",
+    "ioredis": "^5.5.0",
     "msgpack-lite": "^0.1.26",
-    "pump": "^3.0.0",
-    "qlobber": "^7.0.0",
-    "through2": "^4.0.2",
-    "throughv": "^1.0.4"
+    "qlobber": "^8.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aedes-persistence-redis",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Aedes persistence, backed by redis",
   "main": "persistence.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aedes-persistence-redis",
-  "version": "9.0.2",
+  "version": "10.0.0",
   "description": "Aedes persistence, backed by redis",
   "main": "persistence.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "nyc": "^17.1.0"
   },
   "dependencies": {
-    "aedes-cached-persistence": "10.0.101",
+    "aedes-cached-persistence": "10.0.102",
     "hashlru": "^2.3.0",
     "ioredis": "^5.5.0",
     "msgpack-lite": "^0.1.26",

--- a/persistence.js
+++ b/persistence.js
@@ -90,7 +90,7 @@ async function * createWillStream (db, brokers, maxWills) {
   const results = await db.lrange(WILLSKEY, 0, maxWills)
   for (const key of results) {
     const result = await getDecodedValue(db, WILLSKEY, key)
-    if (!brokers || !brokers[result.split(':')[1]]) {
+    if (!brokers || !brokers[key.split(':')[1]]) {
       yield result
     }
   }

--- a/persistence.js
+++ b/persistence.js
@@ -148,7 +148,8 @@ class RedisPersistence extends CachedPersistence {
     for (const pattern of patterns) {
       qlobber.add(pattern)
     }
-    return Readable.from(matchRetained(this.db, qlobber, this.hasClusters))
+
+    return Readable.from(matchRetained(this._db, qlobber, this.hasClusters))
   }
 
   createRetainedStream (pattern) {
@@ -552,8 +553,8 @@ class RedisPersistence extends CachedPersistence {
   }
 }
 
-function * matchRetained (db, qlobber, hasClusters) {
-  for (const key of getRetainedKeys(db, hasClusters)) {
+async function * matchRetained (db, qlobber, hasClusters) {
+  for (const key of await getRetainedKeys(db, hasClusters)) {
     const topic = hasClusters ? decodeURIComponent(key.split(':')[1]) : key
     if (qlobber.test(topic)) {
       yield getRetainedValue(db, topic, hasClusters)

--- a/persistence.js
+++ b/persistence.js
@@ -554,7 +554,14 @@ function returnSubsForClient (subs) {
   }
 
   for (const subKey of subKeys) {
-    toReturn.push(msgpack.decode(subs[subKey]))
+    if (subs[subKey].length === 1) { // version 8x fallback, QoS saved not encoded object
+      toReturn.push({
+        topic: subKey,
+        qos: parseInt(subs[subKey])
+      })
+    } else {
+      toReturn.push(msgpack.decode(subs[subKey]))
+    }
   }
 
   return toReturn

--- a/test-clusters.js
+++ b/test-clusters.js
@@ -1,0 +1,63 @@
+const test = require('tape').test
+const persistence = require('./persistence')
+const Redis = require('ioredis')
+const mqemitterRedis = require('mqemitter-redis')
+const abs = require('aedes-cached-persistence/abstract')
+
+function unref () {
+  this.connector.stream.unref()
+}
+
+const nodes = [
+  { host: 'localhost', port: 6378 },
+  { host: 'localhost', port: 6380 },
+  { host: 'localhost', port: 6381 },
+  { host: 'localhost', port: 6382 },
+  { host: 'localhost', port: 6383 },
+  { host: 'localhost', port: 6384 }
+]
+
+const db = new Redis.Cluster(nodes)
+
+db.on('error', e => {
+  console.trace(e)
+})
+
+db.on('ready', function () {
+  abs({
+    test,
+    buildEmitter () {
+      const emitter = mqemitterRedis()
+      emitter.subConn.on('connect', unref)
+      emitter.pubConn.on('connect', unref)
+
+      return emitter
+    },
+    persistence (cb) {
+      const slaves = db.nodes('master')
+      Promise.all(slaves.map(function (node) {
+        return node.flushdb().catch(err => {
+          console.error('flushRedisKeys-error:', err)
+        })
+      })).then(() => {
+        const conn = new Redis.Cluster(nodes)
+
+        conn.on('error', e => {
+          console.trace(e)
+        })
+
+        conn.on('ready', function () {
+          cb(null, persistence({
+            conn,
+            cluster: true
+          }))
+        })
+      })
+    },
+    waitForReady: true
+  })
+
+  test.onFinish(() => {
+    process.exit(0)
+  })
+})

--- a/test.js
+++ b/test.js
@@ -1,45 +1,69 @@
-const test = require('tape').test
+const test = require('node:test')
 const persistence = require('./')
 const Redis = require('ioredis')
 const mqemitterRedis = require('mqemitter-redis')
 const abs = require('aedes-cached-persistence/abstract')
-const db = new Redis()
 
-db.on('error', e => {
-  console.trace(e)
-})
+function sleep (sec) {
+  return new Promise(resolve => setTimeout(resolve, sec * 1000))
+}
 
-db.on('connect', unref)
+function waitForEvent (obj, resolveEvt) {
+  return new Promise((resolve, reject) => {
+    obj.once(resolveEvt, () => {
+      resolve()
+    })
+    obj.once('error', reject)
+  })
+}
 
+function setUpPersistence (t, id, persistenceOpts) {
+  const emitter = mqemitterRedis()
+  const instance = persistence(persistenceOpts)
+  instance.broker = toBroker(id, emitter)
+  t.diagnostic(`instance ${id} created`)
+  return { instance, emitter, id }
+}
+
+function cleanUpPersistence (t, { instance, emitter, id }) {
+  instance.destroy()
+  emitter.close()
+  t.diagnostic(`instance ${id} destroyed`)
+}
+
+function toBroker (id, emitter) {
+  return {
+    id,
+    publish: emitter.emit.bind(emitter),
+    subscribe: emitter.on.bind(emitter),
+    unsubscribe: emitter.removeListener.bind(emitter)
+  }
+}
 function unref () {
   this.connector.stream.unref()
 }
 
-test('external Redis conn', t => {
+// testing starts here
+const db = new Redis()
+db.on('error', e => {
+  console.trace(e)
+})
+db.on('connect', unref)
+
+test('external Redis conn', async t => {
   t.plan(2)
-
   const externalRedis = new Redis()
-  const emitter = mqemitterRedis()
-
-  db.on('error', e => {
-    t.notOk(e)
-  })
-
-  db.on('connect', () => {
-    t.pass('redis connected')
-  })
-  const instance = persistence({
+  await waitForEvent(externalRedis, 'connect')
+  t.diagnostic('redis connected')
+  t.assert.ok(true, 'redis connected')
+  const p = setUpPersistence(t, '1', {
     conn: externalRedis
   })
-
-  instance.broker = toBroker('1', emitter)
-
-  instance.on('ready', () => {
-    t.pass('instance ready')
-    externalRedis.disconnect()
-    instance.destroy()
-    emitter.close()
-  })
+  await waitForEvent(p.instance, 'ready')
+  t.assert.ok(true, 'instance ready')
+  t.diagnostic('instance ready')
+  externalRedis.disconnect()
+  cleanUpPersistence(t, p)
 })
 
 abs({
@@ -51,73 +75,64 @@ abs({
 
     return emitter
   },
-  persistence () {
+  persistence: () => {
     db.flushall()
     return persistence()
   },
   waitForReady: true
 })
 
-function toBroker (id, emitter) {
-  return {
-    id,
-    publish: emitter.emit.bind(emitter),
-    subscribe: emitter.on.bind(emitter),
-    unsubscribe: emitter.removeListener.bind(emitter)
-  }
-}
+test('packet ttl', async t => {
+  t.plan(3)
+  // the promise is required for the test to wait for the end event
+  const executeTest = new Promise((resolve, reject) => {
+    db.flushall()
 
-test('packet ttl', t => {
-  t.plan(4)
-  db.flushall()
-  const emitter = mqemitterRedis()
-  const instance = persistence({
-    packetTTL () {
-      return 1
+    const p = setUpPersistence(t, '1', {
+      packetTTL () {
+        return 1
+      }
+    })
+    const instance = p.instance
+
+    const subs = [{
+      clientId: 'ttlTest',
+      topic: 'hello',
+      qos: 1
+    }]
+    const packet = {
+      cmd: 'publish',
+      topic: 'hello',
+      payload: 'ttl test',
+      qos: 1,
+      retain: false,
+      brokerId: instance.broker.id,
+      brokerCounter: 42
     }
-  })
-  instance.broker = toBroker('1', emitter)
-
-  const subs = [{
-    clientId: 'ttlTest',
-    topic: 'hello',
-    qos: 1
-  }]
-  const packet = {
-    cmd: 'publish',
-    topic: 'hello',
-    payload: 'ttl test',
-    qos: 1,
-    retain: false,
-    brokerId: instance.broker.id,
-    brokerCounter: 42
-  }
-  instance.outgoingEnqueueCombi(subs, packet, function enqueued (err, saved) {
-    t.notOk(err)
-    t.deepEqual(saved, packet)
-    setTimeout(() => {
+    instance.outgoingEnqueueCombi(subs, packet, async function enqueued (err, saved) {
+      t.assert.ifError(err)
+      t.assert.deepEqual(saved, packet)
+      await sleep(1)
       const offlineStream = instance.outgoingStream({ id: 'ttlTest' })
-      offlineStream.on('data', offlinePacket => {
-        t.notOk(offlinePacket)
-      })
-      offlineStream.on('end', () => {
-        instance.destroy(t.pass.bind(t, 'stop instance'))
-        emitter.close(t.pass.bind(t, 'stop emitter'))
-      })
-    }, 1100)
+      for await (const offlinePacket of offlineStream) {
+        t.assert.ok(!offlinePacket)
+      }
+      cleanUpPersistence(t, p)
+      resolve()
+    })
   })
+  await executeTest
 })
 
-test('outgoingUpdate doesn\'t clear packet ttl', t => {
-  t.plan(5)
+test('outgoingUpdate doesn\'t clear packet ttl', async t => {
+  t.plan(3)
   db.flushall()
-  const emitter = mqemitterRedis()
-  const instance = persistence({
+  const p = setUpPersistence(t, '1', {
     packetTTL () {
       return 1
     }
   })
-  instance.broker = toBroker('1', emitter)
+  const instance = p.instance
 
   const client = {
     id: 'ttlTest'
@@ -137,173 +152,172 @@ test('outgoingUpdate doesn\'t clear packet ttl', t => {
     brokerCounter: 42,
     messageId: 123
   }
-  instance.outgoingEnqueueCombi(subs, packet, function enqueued (err, saved) {
-    t.notOk(err)
-    t.deepEqual(saved, packet)
-    instance.outgoingUpdate(client, packet, function updated () {
-      setTimeout(() => {
+
+  await new Promise((resolve, reject) => {
+    instance.outgoingEnqueueCombi(subs, packet, function enqueued (err, saved) {
+      t.assert.ifError(err)
+      t.assert.deepEqual(saved, packet)
+      instance.outgoingUpdate(client, packet, async function updated () {
+        await sleep(2)
         db.exists('packet:1:42', (_, exists) => {
-          t.notOk(exists, 'packet key should have expired')
+          t.assert.ok(!exists, 'packet key should have expired')
+          cleanUpPersistence(t, p)
+          resolve()
         })
-        instance.destroy(t.pass.bind(t, 'instance dies'))
-        emitter.close(t.pass.bind(t, 'emitter dies'))
-      }, 1100)
-    })
-  })
-})
-
-test('multiple persistences', t => {
-  t.plan(7)
-  t.timeoutAfter(60 * 1000)
-  db.flushall()
-  const emitter = mqemitterRedis()
-  const emitter2 = mqemitterRedis()
-  const instance = persistence()
-  const instance2 = persistence()
-  instance.broker = toBroker('1', emitter)
-  instance2.broker = toBroker('2', emitter2)
-
-  const client = { id: 'multipleTest' }
-  const subs = [{
-    topic: 'hello',
-    qos: 1
-  }, {
-    topic: 'hello/#',
-    qos: 1
-  }, {
-    topic: 'matteo',
-    qos: 1
-  }]
-
-  let gotSubs = false
-  let addedSubs = false
-
-  function close () {
-    if (gotSubs && addedSubs) {
-      instance.destroy(t.pass.bind(t, 'first dies'))
-      instance2.destroy(t.pass.bind(t, 'second dies'))
-      emitter.close(t.pass.bind(t, 'first emitter dies'))
-      emitter2.close(t.pass.bind(t, 'second emitter dies'))
-    }
-  }
-
-  instance2._waitFor(client, true, 'hello', () => {
-    instance2.subscriptionsByTopic('hello', (err, resubs) => {
-      t.notOk(err, 'subs by topic no error')
-      t.deepEqual(resubs, [{
-        clientId: client.id,
-        topic: 'hello/#',
-        qos: 1,
-        rh: undefined,
-        rap: undefined,
-        nl: undefined
-      }, {
-        clientId: client.id,
-        topic: 'hello',
-        qos: 1,
-        rh: undefined,
-        rap: undefined,
-        nl: undefined
-      }], 'received correct subs')
-      gotSubs = true
-      close()
-    })
-  })
-
-  let ready = false
-  let ready2 = false
-
-  function addSubs () {
-    if (ready && ready2) {
-      instance.addSubscriptions(client, subs, err => {
-        t.notOk(err, 'add subs no error')
-        addedSubs = true
-        close()
       })
-    }
-  }
-
-  instance.on('ready', () => {
-    ready = true
-    addSubs()
-  })
-
-  instance2.on('ready', () => {
-    ready2 = true
-    addSubs()
+    })
   })
 })
 
-test('unknown cache key', t => {
+test('multiple persistences', {
+  timeout: 60 * 1000
+}, async t => {
   t.plan(3)
-  db.flushall()
-  const emitter = mqemitterRedis()
-  const instance = persistence()
-  const client = { id: 'unknown_pubrec' }
+  const executeTest = new Promise((resolve, reject) => {
+    db.flushall()
+    const p1 = setUpPersistence(t, '1')
+    const p2 = setUpPersistence(t, '2')
+    const instance = p1.instance
+    const instance2 = p2.instance
 
-  instance.broker = toBroker('1', emitter)
+    const client = { id: 'multipleTest' }
+    const subs = [{
+      topic: 'hello',
+      qos: 1
+    }, {
+      topic: 'hello/#',
+      qos: 1
+    }, {
+      topic: 'matteo',
+      qos: 1
+    }]
 
-  // packet with no brokerId
-  const packet = {
-    cmd: 'pubrec',
-    topic: 'hello',
-    qos: 2,
-    retain: false
-  }
+    let gotSubs = false
+    let addedSubs = false
 
-  function close () {
-    instance.destroy(t.pass.bind(t, 'instance dies'))
-    emitter.close(t.pass.bind(t, 'emitter dies'))
-  }
+    function close () {
+      if (gotSubs && addedSubs) {
+        cleanUpPersistence(t, p1)
+        cleanUpPersistence(t, p2)
+        resolve()
+      }
+    }
 
-  instance.outgoingUpdate(client, packet, (err, client, packet) => {
-    t.equal(err.message, 'unknown key', 'Received unknown PUBREC')
-    close()
-  })
-})
-
-test('wills table de-duplicate', t => {
-  t.plan(5)
-  db.flushall()
-  const emitter = mqemitterRedis()
-  const instance = persistence()
-  const client = { id: 'willsTest' }
-
-  instance.broker = toBroker('1', emitter)
-
-  const packet = {
-    cmd: 'publish',
-    topic: 'hello',
-    payload: 'willsTest',
-    qos: 1,
-    retain: false,
-    brokerId: instance.broker.id,
-    brokerCounter: 42,
-    messageId: 123
-  }
-
-  instance.putWill(client, packet, err => {
-    t.notOk(err, 'putWill #1 no error')
-    instance.putWill(client, packet, err => {
-      t.notOk(err, 'putWill #2 no error')
-      let willCount = 0
-      const wills = instance.streamWill()
-      wills.on('data', function (chunk) {
-        willCount++
-      })
-      wills.on('end', function () {
-        t.equal(willCount, 1, 'should only be one will')
+    instance2._waitFor(client, true, 'hello', () => {
+      instance2.subscriptionsByTopic('hello', (err, resubs) => {
+        t.assert.ok(!err, 'subs by topic no error')
+        t.assert.deepEqual(resubs, [{
+          clientId: client.id,
+          topic: 'hello/#',
+          qos: 1,
+          rh: undefined,
+          rap: undefined,
+          nl: undefined
+        }, {
+          clientId: client.id,
+          topic: 'hello',
+          qos: 1,
+          rh: undefined,
+          rap: undefined,
+          nl: undefined
+        }], 'received correct subs')
+        gotSubs = true
         close()
       })
     })
+
+    let ready = false
+    let ready2 = false
+
+    function addSubs () {
+      if (ready && ready2) {
+        instance.addSubscriptions(client, subs, err => {
+          t.assert.ok(!err, 'add subs no error')
+          addedSubs = true
+          close()
+        })
+      }
+    }
+
+    instance.on('ready', () => {
+      ready = true
+      addSubs()
+    })
+
+    instance2.on('ready', () => {
+      ready2 = true
+      addSubs()
+    })
   })
-
-  function close () {
-    instance.destroy(t.pass.bind(t, 'instance dies'))
-    emitter.close(t.pass.bind(t, 'emitter dies'))
-  }
+  await executeTest
 })
 
-test.onFinish(() => {
-  process.exit(0)
+test('unknown cache key', async t => {
+  t.plan(2)
+  const executeTest = new Promise((resolve, reject) => {
+    db.flushall()
+    const p = setUpPersistence(t, '1')
+    const instance = p.instance
+    const client = { id: 'unknown_pubrec' }
+
+    // packet with no brokerId
+    const packet = {
+      cmd: 'pubrec',
+      topic: 'hello',
+      qos: 2,
+      retain: false
+    }
+
+    instance.on('ready', () => {
+      instance.outgoingUpdate(client, packet, (err, client, packet) => {
+        t.assert.ok(err, 'error received')
+        t.assert.equal(err.message, 'unknown key', 'Received unknown PUBREC')
+        cleanUpPersistence(t, p)
+        resolve()
+      })
+    })
+  })
+  await executeTest
 })
+
+test('wills table de-duplicate', async t => {
+  t.plan(3)
+  const executeTest = new Promise((resolve, reject) => {
+    db.flushall()
+    const p = setUpPersistence(t, '1')
+    const instance = p.instance
+    const client = { id: 'willsTest' }
+
+    const packet = {
+      cmd: 'publish',
+      topic: 'hello',
+      payload: 'willsTest',
+      qos: 1,
+      retain: false,
+      brokerId: instance.broker.id,
+      brokerCounter: 42,
+      messageId: 123
+    }
+
+    instance.putWill(client, packet, err => {
+      t.assert.ok(!err, 'putWill #1 no error')
+      instance.putWill(client, packet, err => {
+        t.assert.ok(!err, 'putWill #2 no error')
+        let willCount = 0
+        const wills = instance.streamWill()
+        wills.on('data', (chunk) => {
+          willCount++
+        })
+        wills.on('end', () => {
+          t.assert.equal(willCount, 1, 'should only be one will')
+          cleanUpPersistence(t, p)
+          resolve()
+        })
+      })
+    })
+  })
+  await executeTest
+})
+
+// clients will keep on running after the test
+sleep(10).then(() => process.exit(0))

--- a/tester.js
+++ b/tester.js
@@ -1,4 +1,3 @@
-// npm install mqtt fastq
 // command to run : node fastbench 25000
 const queue = require('fastq')(worker, 1)
 const mqtt = require('mqtt')


### PR DESCRIPTION
### Sync fork with upstream

### Optimize getSharedTopics

This is called on every publish and possibly multiple times while first call is completing. This situation gets amplified in case redis is slow (e.g. during massive reconnect wave) in which case we could generate a lot of calls to fillSharedCache while first one has not yet finished.

In order to avoid this scenario completely I moved fillSharedCache to separate timed call and made getSharedTopics to always use the cache in case fillSharedCache is enabled.