### PR TITLE
RNTL-25522: optimize non-wildcard retained topics handling

### DIFF
--- a/persistence.js
+++ b/persistence.js
@@ -144,7 +144,8 @@ class RedisPersistence extends CachedPersistence {
 
     this.logger = opts.logger || new NoopLogger()
 
-    this.retainedValuesQueryThreshold = opts.retained_values_query_threshold || 1
+    // By default retained values query optimization is disabled (-1)
+    this.retainedValuesQueryThreshold = opts.retained_values_query_threshold || -1
 
     if (this.sharedCacheRefreshIntervalSec) {
       this.once('ready', () => {


### PR DESCRIPTION
Optimize getting retained values for non-wildcard topics. Before all retained keys were read always on every subscribe, now as optimization we just try to read specific values.

If this improves performance depends on the circumstances:
* If there are no retained messages and subscribe is done for many topics then it makes sense to read all retained keys as before since it's just one `hkeys` call vs multiple `hget` calls for individual keys.
* If subscribe is done for just one topic then the new approach is just as good in case there are no retained messages (one `hkeys` vs one `hget`). And in case there are some retained topics it's strictly better. That is why `retained_values_query_threshold` is by default 1.