### PR TITLE
RNTL-25522: Add getRetainedKeys method to RedisPersistence

### DIFF
--- a/persistence.js
+++ b/persistence.js
@@ -200,6 +200,10 @@ class RedisPersistence extends CachedPersistence {
     }
   }
 
+  async getRetainedKeys () {
+    return getRetainedKeys(this._db, this.hasClusters)
+  }
+
   hasWildcard (patterns) {
     return patterns.some((pattern) => pattern.includes('+') || pattern.includes('#'))
   }


### PR DESCRIPTION
Added `getRetainedKeys` to be able to monitor retained keys amount outside of persistence without hardcoding the key path.